### PR TITLE
Remove use of vlans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - DAQ_CODECOV=y
     - DAQ_MODE=in DAQ_BUILD=in DAQ_PUSH=daqf/runner
     - DAQ_MODE=in DAQ_BUILD=no
-    - DAQ_DEVICES=1 DAQ_FAIL=xdhcp
+    - DAQ_DEVICES=1 DAQ_FAIL=telnet
     - DAQ_DEVICES=3
     - DAQ_SWITCH=ext
 branches:

--- a/bin/setup_dev
+++ b/bin/setup_dev
@@ -50,7 +50,7 @@ fi
 
 # Python extension packages.
 pip install --index-url=https://pypi.python.org/simple \
-    netifaces codecov firebase-admin==2.11.0 google-cloud-pubsub==0.32.1
+    netifaces pyyaml codecov firebase-admin==2.11.0 google-cloud-pubsub==0.32.1
 
 # Hack to make pylint happy.
 if [ -d venv ]; then

--- a/bin/test_daq
+++ b/bin/test_daq
@@ -57,7 +57,7 @@ fi
 
 if [ -n "$DAQ_FAIL" ]; then
     if [ -z "$failed" ]; then
-        echo Test did not fail with expected $DAQ_FAIL.
+        echo Test did not fail as expected with $DAQ_FAIL.
         false
     fi
 elif [ -n "$failed" ]; then

--- a/cmd/exrun
+++ b/cmd/exrun
@@ -3,11 +3,13 @@
 ROOT=$(realpath $(dirname $0)/..)
 INSTDIR=$ROOT/inst
 LOCALDIR=$ROOT/local
+FAUCET_LOG=$INSTDIR/faucet.log
 FAUCET_SOCK=faucet_event.sock
 export FAUCET_EVENT_SOCK=$INSTDIR/$FAUCET_SOCK
 SYSTEM_CONF=system.conf
 LOCAL_CONFIG=$LOCALDIR/$SYSTEM_CONF
 export DAQ_VERSION=$(cat $ROOT/misc/RELEASE_VERSION)
+cleanup="echo cleanup"
 
 cd $ROOT
 
@@ -38,7 +40,7 @@ if [ ! -d $FAUCET ]; then
 fi
 
 mkdir -p $INSTDIR
-rm -f $FAUCET_EVENT_SOCK
+rm -f $FAUCET_EVENT_SOCK $FAUCET_LOG
 
 docker ps > /dev/null 2>&1 || service docker start
 sleep 1
@@ -57,17 +59,20 @@ for intf in $intfs; do
         intf=local
         echo Implicitly running local device...
         $ROOT/cmd/local
-        cleanup="$ROOT/cmd/local clean"
+        cleanup+=";$ROOT/cmd/local clean"
     fi
 
-    if [ "$intf" == "faux!" ]; then
-        intf=faux
-        echo Implicitly running faux device...
-        $ROOT/cmd/faux
-        cleanup="echo Killing daq-faux container...; docker kill daq-faux > /dev/null"
+    fbase=${intf%!}
+    fnum=${fbase#faux}
+    if [ "${fbase}" != "${intf}" -a "${fbase}" != "${fnum}" ]; then
+        intf=$fbase
+        echo Implicitly running faux device $intf...
+        $ROOT/cmd/faux ${fnum#-}
+        container=daq-$intf
+        cleanup+=";echo Killing container $container...; docker kill $container > /dev/null"
     fi
 
-    ip -br addr show $intf || true
+    echo $(ip addr show $intf)
 
     # If running inside of a container, wait until the host test interface shows up...
     if [ -n "$DAQ_CONTAINER" -a -z "$cleanup" ]; then

--- a/misc/faucet.yaml
+++ b/misc/faucet.yaml
@@ -1,3 +1,5 @@
+include:
+  - dp_pri_port_acls.yaml
 include-optional:
   - port_acls/dp_sec_port_1_acl.yaml
   - port_acls/dp_sec_port_2_acl.yaml
@@ -9,20 +11,12 @@ dps:
         stack:
           priority: 1
         interface_ranges:
-          10-19:
+          10-69:
+            acl_in: dp_pri_portset_acl
             native_vlan: 10
-          20-29:
-            native_vlan: 20
-          30-39:
-            native_vlan: 30
-          40-49:
-            native_vlan: 40
-          50-59:
-            native_vlan: 50
-          60-69:
-            native_vlan: 60
         interfaces:
           1:
+            acl_in: dp_pri_incoming_acl
             stack:
               dp: sec
               port: @SEC_PORT@
@@ -35,32 +29,22 @@ dps:
             native_vlan: 10
             acl_in: dp_sec_port_1_acl
           2:
-            native_vlan: 20
+            native_vlan: 10
             acl_in: dp_sec_port_2_acl
           3:
-            native_vlan: 30
+            native_vlan: 10
           4:
-            native_vlan: 40
+            native_vlan: 10
           5:
-            native_vlan: 50
+            native_vlan: 10
           6:
-            native_vlan: 60
+            native_vlan: 10
           @SEC_PORT@:
             stack:
               dp: pri
               port: 1
 vlans:
     10:
-      description: default vlan
-    20:
-      description: default vlan
-    30:
-      description: default vlan
-    40:
-      description: default vlan
-    50:
-      description: default vlan
-    60:
       description: default vlan
 acls:
   dp_sec_port_1_acl:


### PR DESCRIPTION
Change internal working of DAQ to use explicit output control rather than vlans. This is necessary down the road to enable more flexible groupings of devices (that don't 1:1 correlate with a single vlan). Also implement basics for dynamic event-handling that can be used later on for MUD file application.
