### PR TITLE
Upstream port mirroring for intra-device traffic

### DIFF
--- a/cmd/exrun
+++ b/cmd/exrun
@@ -55,6 +55,11 @@ if [ ! -d $FAUCET ]; then
     false
 fi
 
+if [ -n "$device_specs" ]; then
+    echo Creating MUD templates for $device_specs...
+    bin/mudacl $device_specs
+fi
+
 mkdir -p $INSTDIR
 rm -f $FAUCET_EVENT_SOCK $FAUCET_LOG
 

--- a/daq/topology.py
+++ b/daq/topology.py
@@ -142,7 +142,7 @@ class FaucetTopology():
     def _make_default_acl_rules(self):
         rules = []
         if not self._append_acl_template(rules, 'raw'):
-            rules += [self._make_default_allow_rule()]
+            self._augment_and_append(self._make_default_allow_rule(), rules)
         return rules
 
     def _make_default_acls(self):
@@ -363,6 +363,9 @@ class FaucetTopology():
         subrule = {'actions': actions}
         return {'rule': subrule}
 
+    def _augment_and_append(self, acls, rules):
+        rules.append(acls)
+
     def _append_device_default_allow(self, rules, target_mac):
         device_spec = self._device_specs['macAddrs'].get(target_mac)
         if device_spec and 'default_allow' in device_spec:
@@ -370,8 +373,8 @@ class FaucetTopology():
             actions = {'allow': allow_action}
             subrule = {'actions': actions}
             subrule['description'] = "device_spec default_allow"
-            rule = {'rule': subrule}
-            rules.append(rule)
+            acl = {'rule': subrule}
+            self._augment_and_append(acl, rules)
 
     def _append_acl_template(self, rules, template, target_mac=None):
         filename = self.TEMPLATE_FILE_FORMAT % template
@@ -383,7 +386,7 @@ class FaucetTopology():
             new_rule = acl['rule']
             self._resolve_template_field(new_rule, 'dl_src', target_mac=target_mac)
             self._resolve_template_field(new_rule, 'nw_dst')
-            rules.append(acl)
+            self._augment_and_append(acl, rules)
         return True
 
     def _resolve_template_field(self, rule, field, target_mac=None):

--- a/daq/topology.py
+++ b/daq/topology.py
@@ -367,7 +367,7 @@ class FaucetTopology():
         actions = acls['rule']['actions']
         assert not 'output' in actions, 'output actions explicitly defined'
         if actions['allow']:
-            actions['output'] = { 'port': self.sec_port }
+            actions['output'] = {'port': self.sec_port}
         return acls
 
     def _append_device_default_allow(self, rules, target_mac):


### PR DESCRIPTION
With this change, the system mirrors intra-device traffic upstream, so that it can be monitored/tested from the primary (internal) switch.  Without this, intra-device trafic stay switch-local on the secondary (potentially external) switch. E.g., ping traffic between devices looks something like:

```
~/daq$ sudo tcpdump -eni pri-eth1 icmp
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on pri-eth1, link-type EN10MB (Ethernet), capture size 262144 bytes
09:32:45.239429 9a:02:57:1e:8f:02 > 9a:02:57:1e:8f:03, ethertype IPv4 (0x0800), length 98: 10.20.88.163 > 10.20.88.164: ICMP echo request, id 445, seq 1, length 64
09:32:45.239504 9a:02:57:1e:8f:03 > 9a:02:57:1e:8f:02, ethertype IPv4 (0x0800), length 98: 10.20.88.164 > 10.20.88.163: ICMP echo reply, id 445, seq 1, length 64

```