### PR TITLE
Update gradle wrapper to 5.1.1 for higher java support

### DIFF
--- a/mudacl/bin/run.sh
+++ b/mudacl/bin/run.sh
@@ -15,4 +15,4 @@ acl_templates=$2
 echo
 echo Executing mudacl generator on $mud_files...
 
-java -jar $MUDACL/build/libs/mudacl-1.0-SNAPSHOT-all.jar $mud_files $acl_templates
+java -jar $MUDACL/build/libs/mudacl-1.0-SNAPSHOT.jar $mud_files $acl_templates

--- a/mudacl/bin/test.sh
+++ b/mudacl/bin/test.sh
@@ -12,7 +12,7 @@ echo Running mudacl regression test...
 rm -rf $OUTDIR || sudo rm -rf $OUTDIR
 mkdir -p $OUTDIR/acl_templates $OUTDIR/port_acls
 
-java -jar build/libs/mudacl-1.0-SNAPSHOT-all.jar ../mud_files $OUTDIR/acl_templates/ \
+java -jar build/libs/mudacl-1.0-SNAPSHOT.jar ../mud_files $OUTDIR/acl_templates/ \
      $SETUP/faucet.yaml $SETUP/devices.json $SETUP/cabling.json $OUTDIR/port_acls/
 
 echo Compare $OUTDIR/acl_templates/ with $SETUP/acl_templates/...

--- a/mudacl/gradle/wrapper/gradle-wrapper.properties
+++ b/mudacl/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
- Updates gradle wrapper to 5.1.1 for mudacl files to allow for java higher than 1.8 to be used locally
- Update shadow jar naming changes that occur in gradle update