### PR TITLE
adding libffi-dev dependencies

### DIFF
--- a/bin/setup_dev
+++ b/bin/setup_dev
@@ -62,7 +62,7 @@ $AG install \
     ca-certificates sudo net-tools tcpdump build-essential \
     isc-dhcp-client network-manager netcat gnupg2 strace \
     python3 python3-pkg-resources python3-setuptools python3-dev \
-    python3-pip openjdk-8-jdk python emacs-nox python3-venv jq
+    python3-pip openjdk-8-jdk python emacs-nox python3-venv libffi-dev jq
 
 # Jump through some hoops for mininet, which still has some python2 deps.
 $AG install python-pip


### PR DESCRIPTION
the bin/setup_dev script triggers pip to install cffi as a dependencies.
cffi depends on libffi-dev and fails if this package has not been pre-installed