### PR TITLE
nmap port scan tests

### DIFF
--- a/bin/setup_base
+++ b/bin/setup_base
@@ -14,7 +14,7 @@ if [ -z "$AG" ]; then
 fi
 
 #Store all additional apt-get arguments passed into this script.
-#These arguments are unchecked 
+#These arguments are unchecked
 AG_ARGS="$@"
 
 #Append all additional apt-get arguments to AG
@@ -22,7 +22,7 @@ if [ ! -z "$AG_ARGS" ];then
     AG="$AG $AG_ARGS"
 fi
 
-echo AG is $AG 
+echo AG is $AG
 
 # Hacky workaround for https://travis-ci.community/t/sometimes-build-fails-when-apt-is-updating-postgresql-apt-repository/4872/17
 # Need to remove the || true at the end of the update line. Same as for instance below. Also in bin/setup_dev.
@@ -40,7 +40,7 @@ echo Installing for $distrib $release
 echo "deb http://packages.wand.net.nz $release main" | sudo tee /etc/apt/sources.list.d/wand.list
 $retry sudo curl http://packages.wand.net.nz/keyring.gpg -o /etc/apt/trusted.gpg.d/wand.gpg
 
-$retry curl -fsSL https://download.docker.com/linux/$distrib/gpg | sudo apt-key add -
+$retry curl -4fsSL https://download.docker.com/linux/$distrib/gpg | sudo apt-key add -
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$distrib $release stable" || true
 
 # Hacky workaround for https://travis-ci.community/t/sometimes-build-fails-when-apt-is-updating-postgresql-apt-repository/4872/17

--- a/bin/setup_dev
+++ b/bin/setup_dev
@@ -62,7 +62,7 @@ $AG install \
     ca-certificates sudo net-tools tcpdump build-essential \
     isc-dhcp-client network-manager netcat gnupg2 strace \
     python3 python3-pkg-resources python3-setuptools python3-dev \
-    python3-pip openjdk-8-jdk python emacs-nox python3-venv libffi-dev jq pandoc
+    python3-pip openjdk-8-jdk python emacs-nox python3-venv libffi-dev python3-cairocffi jq pandoc
 
 # Jump through some hoops for mininet, which still has some python2 deps.
 $AG install python-pip

--- a/cmd/faucet
+++ b/cmd/faucet
@@ -50,7 +50,7 @@ echo Creating $IMAGE instance $CONTAINER on port $ext_ofpt in $INSTDIR
 mkdir -p $INSTDIR
 
 if docker container inspect $CONTAINER --format '{{ .Name }}' > /dev/null 2>&1; then
-    echo -n "Clensing old container "
+    echo -n "Cleansing old container "
     docker rm -f $CONTAINER
 fi
 

--- a/cmd/faux
+++ b/cmd/faux
@@ -56,7 +56,7 @@ fi
 echo Launching faux $FAUX_ARGS...
 
 if docker container inspect $CONTAINER --format '{{ .Name }}' > /dev/null 2>&1; then
-    echo -n "Clensing old container "
+    echo -n "Cleansing old container "
     docker rm -f $CONTAINER
 fi
 

--- a/daq/report.py
+++ b/daq/report.py
@@ -13,6 +13,12 @@ import pypandoc
 import weasyprint
 
 import logger
+import logging
+#print(dir(logging.getLogger('weasyprint')))
+#logging.getLogger('weasyprint').setLevel(10)
+wplogger = logging.getLogger("weasyprint")
+if not wplogger.handlers:
+    wplogger.addHandler(logging.NullHandler())
 
 LOGGER = logger.get_logger('report')
 

--- a/daq/report.py
+++ b/daq/report.py
@@ -13,16 +13,6 @@ import pypandoc
 import weasyprint
 
 import logger
-import logging
-#print(dir(logging.getLogger('weasyprint')))
-#logging.getLogger('weasyprint').setLevel(10)
-wpLog = logging.getLogger('weasyprint')
-level = logging.getLevelName('INFO')
-wpLog.setLevel(level)
-
-#wplogger = logging.getLogger("weasyprint")
-#if not wplogger.handlers:
-#    wplogger.addHandler(logging.NullHandler())
 
 LOGGER = logger.get_logger('report')
 

--- a/daq/report.py
+++ b/daq/report.py
@@ -16,9 +16,13 @@ import logger
 import logging
 #print(dir(logging.getLogger('weasyprint')))
 #logging.getLogger('weasyprint').setLevel(10)
-wplogger = logging.getLogger("weasyprint")
-if not wplogger.handlers:
-    wplogger.addHandler(logging.NullHandler())
+wpLog = logging.getLogger('weasyprint')
+level = logging.getLevelName('INFO')
+wpLog.setLevel(level)
+
+#wplogger = logging.getLogger("weasyprint")
+#if not wplogger.handlers:
+#    wplogger.addHandler(logging.NullHandler())
 
 LOGGER = logger.get_logger('report')
 

--- a/docs/device_report.md
+++ b/docs/device_report.md
@@ -11,8 +11,8 @@
 
 | Test             |                        |
 |------------------|------------------------|
-| Test report start date | 2019-10-22 09:34:33+00:00 |
-| Test report end date   | 2019-10-22 09:41:18+00:00 |
+| Test report start date | 2020-02-21 18:04:04+00:00 |
+| Test report end date   | 2020-02-21 18:11:02+00:00 |
 | DAQ version      | 1.0.1 |
 | Attempt number   | 1 |
 
@@ -54,9 +54,9 @@ Overall device result FAIL
 
 |Expectation|pass|fail|skip|gone|
 |---|---|---|---|---|
-|Required|1|1|0|0|
+|Required|1|0|0|0|
 |Recommended|1|0|0|0|
-|Other|0|1|17|2|
+|Other|0|2|17|2|
 
 |Result|Test|Category|Expectation|Notes|
 |---|---|---|---|---|
@@ -67,18 +67,18 @@ Overall device result FAIL
 |skip|connection.port_duplex|Other|Other|No local IP has been set, check ext_loip in system.conf|
 |skip|connection.port_link|Other|Other|No local IP has been set, check ext_loip in system.conf|
 |skip|connection.port_speed|Other|Other|No local IP has been set, check ext_loip in system.conf|
-|fail|network.brute|Security|Required|Change the default password on the DUT|
 |skip|poe.negotiation|Other|Other|No local IP has been set, check ext_loip in system.conf|
 |skip|poe.power|Other|Other|No local IP has been set, check ext_loip in system.conf|
 |skip|poe.support|Other|Other|No local IP has been set, check ext_loip in system.conf|
 |skip|protocol.bacnet.pic|Other|Other|Bacnet device not found.|
 |skip|protocol.bacnet.version|Other|Other|Bacnet device not found.|
+|fail|security.brute|Other|Other|Change the default password on the DUT|
 |skip|security.firmware|Other|Other|Could not retrieve a firmware version with nmap. Check bacnet port.|
 |skip|security.passwords.http|Other|Other|Could not lookup password info for mac-key 9a:02:57:1e:8f:01|
 |skip|security.passwords.https|Other|Other|Could not lookup password info for mac-key 9a:02:57:1e:8f:01|
 |skip|security.passwords.ssh|Other|Other|Could not lookup password info for mac-key 9a:02:57:1e:8f:01|
 |skip|security.passwords.telnet|Other|Other|Could not lookup password info for mac-key 9a:02:57:1e:8f:01|
-|pass|security.ports.nmap|Security|Recommended||
+|pass|security.ports.nmap|Security|Recommended|Only allowed ports found open.|
 |skip|security.tls.v3|Other|Other||
 |skip|security.x509|Other|Other||
 |gone|unknown.fake.llama|Other|Other||
@@ -111,7 +111,7 @@ Attempt to ping the Device Under Test
 --------------------
 See log above
 --------------------
-RESULT pass base.target.ping target reached %% 10.20.70.164
+RESULT pass base.target.ping target reached %% 10.20.33.164
 
 ```
 
@@ -123,10 +123,12 @@ security.ports.nmap
 --------------------
 Automatic TCP/UDP port scan using nmap
 --------------------
-Allowing 10000 open tcp snet-sensor-mgmt
+# Nmap 7.60 scan initiated Fri Feb 21 18:10:24 2020 as: nmap -v -n -Pn -T5 -sU -sT --open -pU:123,161,162,47808,69,T:110,143,161,162,20,21,22,23,25,443,5500,5800,80, -oG /tmp/nmap.log 10.20.33.164
+# Ports scanned: TCP(13;20-23,25,80,110,143,161-162,443,5500,5800) UDP(5;69,123,161-162,47808) SCTP(0;) PROTOCOLS(0;)
+# Nmap done at Fri Feb 21 18:10:24 2020 -- 1 IP address (1 host up) scanned in 0.58 seconds
 No invalid ports found.
 --------------------
-RESULT pass security.ports.nmap 
+RESULT pass security.ports.nmap Only allowed ports found open.
 
 ```
 
@@ -134,7 +136,7 @@ RESULT pass security.ports.nmap
 
 ```
 --------------------
-network.brute
+security.brute
 --------------------
 Educational test - not to be included in a production environment!
 --------------------
@@ -142,7 +144,7 @@ Username:manager
 Password:friend
 Login success!
 --------------------
-RESULT fail network.brute Change the default password on the DUT
+RESULT fail security.brute Change the default password on the DUT
 
 ```
 
@@ -263,7 +265,7 @@ RESULT skip protocol.bacnet.pic Bacnet device not found.
 
 ```
 --------------------
-Collecting TLS cert from target address %% 10.20.96.164
+Collecting TLS cert from target address %% 10.20.33.164
 IOException unable to connect to server.
 
 --------------------

--- a/docs/device_report.md
+++ b/docs/device_report.md
@@ -11,8 +11,8 @@
 
 | Test             |                        |
 |------------------|------------------------|
-| Test report start date | 2020-02-21 18:04:04+00:00 |
-| Test report end date   | 2020-02-21 18:11:02+00:00 |
+| Test report start date | 2020-02-22 00:19:09+00:00 |
+| Test report end date   | 2020-02-22 00:26:00+00:00 |
 | DAQ version      | 1.0.1 |
 | Attempt number   | 1 |
 
@@ -90,7 +90,7 @@ Overall device result FAIL
 ```
 --------------------
 Baseline ping test report
-%% 61 packets captured.
+%% 72 packets captured.
 LOCAL_IP not configured, assuming no network switch
 
 Done with basic connectivity tests
@@ -111,7 +111,7 @@ Attempt to ping the Device Under Test
 --------------------
 See log above
 --------------------
-RESULT pass base.target.ping target reached %% 10.20.33.164
+RESULT pass base.target.ping target reached %% 10.20.59.164
 
 ```
 
@@ -123,9 +123,9 @@ security.ports.nmap
 --------------------
 Automatic TCP/UDP port scan using nmap
 --------------------
-# Nmap 7.60 scan initiated Fri Feb 21 18:10:24 2020 as: nmap -v -n -Pn -T5 -sU -sT --open -pU:123,161,162,47808,69,T:110,143,161,162,20,21,22,23,25,443,5500,5800,80, -oG /tmp/nmap.log 10.20.33.164
+# Nmap 7.60 scan initiated Sat Feb 22 00:25:19 2020 as: nmap -v -n -Pn -T5 -sU -sT --open -pU:123,161,162,47808,69,T:110,143,161,162,20,21,22,23,25,443,5500,5800,80, -oG /tmp/nmap.log 10.20.59.164
 # Ports scanned: TCP(13;20-23,25,80,110,143,161-162,443,5500,5800) UDP(5;69,123,161-162,47808) SCTP(0;) PROTOCOLS(0;)
-# Nmap done at Fri Feb 21 18:10:24 2020 -- 1 IP address (1 host up) scanned in 0.58 seconds
+# Nmap done at Sat Feb 22 00:25:20 2020 -- 1 IP address (1 host up) scanned in 0.58 seconds
 No invalid ports found.
 --------------------
 RESULT pass security.ports.nmap Only allowed ports found open.
@@ -265,7 +265,7 @@ RESULT skip protocol.bacnet.pic Bacnet device not found.
 
 ```
 --------------------
-Collecting TLS cert from target address %% 10.20.33.164
+Collecting TLS cert from target address %% 10.20.59.164
 IOException unable to connect to server.
 
 --------------------

--- a/docs/device_report.md
+++ b/docs/device_report.md
@@ -11,8 +11,8 @@
 
 | Test             |                        |
 |------------------|------------------------|
-| Test report start date | 2020-02-22 00:19:09+00:00 |
-| Test report end date   | 2020-02-22 00:26:00+00:00 |
+| Test report start date | 2020-02-22 17:19:17+00:00 |
+| Test report end date   | 2020-02-22 17:26:33+00:00 |
 | DAQ version      | 1.0.1 |
 | Attempt number   | 1 |
 
@@ -90,7 +90,7 @@ Overall device result FAIL
 ```
 --------------------
 Baseline ping test report
-%% 72 packets captured.
+%% 70 packets captured.
 LOCAL_IP not configured, assuming no network switch
 
 Done with basic connectivity tests
@@ -111,7 +111,7 @@ Attempt to ping the Device Under Test
 --------------------
 See log above
 --------------------
-RESULT pass base.target.ping target reached %% 10.20.59.164
+RESULT pass base.target.ping target reached %% 10.20.28.164
 
 ```
 
@@ -123,9 +123,9 @@ security.ports.nmap
 --------------------
 Automatic TCP/UDP port scan using nmap
 --------------------
-# Nmap 7.60 scan initiated Sat Feb 22 00:25:19 2020 as: nmap -v -n -Pn -T5 -sU -sT --open -pU:123,161,162,47808,69,T:110,143,161,162,20,21,22,23,25,443,5500,5800,80, -oG /tmp/nmap.log 10.20.59.164
+# Nmap 7.60 scan initiated Sat Feb 22 17:25:53 2020 as: nmap -v -n -Pn -T5 -sU -sT --open -pU:123,161,162,47808,69,T:110,143,161,162,20,21,22,23,25,443,5500,5800,80, -oG /tmp/nmap.log 10.20.28.164
 # Ports scanned: TCP(13;20-23,25,80,110,143,161-162,443,5500,5800) UDP(5;69,123,161-162,47808) SCTP(0;) PROTOCOLS(0;)
-# Nmap done at Sat Feb 22 00:25:20 2020 -- 1 IP address (1 host up) scanned in 0.58 seconds
+# Nmap done at Sat Feb 22 17:25:54 2020 -- 1 IP address (1 host up) scanned in 0.61 seconds
 No invalid ports found.
 --------------------
 RESULT pass security.ports.nmap Only allowed ports found open.
@@ -265,7 +265,7 @@ RESULT skip protocol.bacnet.pic Bacnet device not found.
 
 ```
 --------------------
-Collecting TLS cert from target address %% 10.20.59.164
+Collecting TLS cert from target address %% 10.20.28.164
 IOException unable to connect to server.
 
 --------------------

--- a/misc/test_site/mac_addrs/9a02571e8f01/module_config.json
+++ b/misc/test_site/mac_addrs/9a02571e8f01/module_config.json
@@ -24,13 +24,81 @@
   "servers": {
     "tcp": {
       "ports": {
+        "20": {
+          "allowed": false,
+          "reason": "File Transfer Protocol (FTP) Server Data Transfer"
+        },
+        "21": {
+          "allowed": false,
+          "reason": "File Transfer Protocol (FTP) Server Data Transfer"
+        },
+        "22": {
+          "allowed": true,
+          "reason": "Secure Shell (SSH) server"
+        },
+        "23": {
+          "allowed": false,
+          "reason": "Telnet Server"
+        },
+        "25": {
+          "allowed": false,
+          "reason": "Simple Mail Transfer Protocol (SMTP) Server"
+        },
+        "80": {
+          "allowed": false,
+          "reason": "Administrative Insecure Web-Server"
+        },
+        "110": {
+          "allowed": false,
+          "reason": "Post Office Protocol v3 (POP3) Server"
+        },
+        "143": {
+          "allowed": false,
+          "reason": "Internet Message Access Protocol (IMAP) Server"
+        },
+        "161": {
+          "allowed": false,
+          "reason": "Simple Network Management Protocol (SNMP)"
+        },
+        "162": {
+          "allowed": false,
+          "reason": "Simple Network Management Protocol (SNMP) Trap"
+        },
         "443": {
           "allowed": true,
-          "reason": "Administrative Web-Server"
+          "reason": "Administrative Secure Web-Server"
         },
-        "10000": {
+        "5800": {
+          "allowed": false,
+          "reason": "Virtual Network Computing (VNC) Remote Frame Buffer Protocol Over HTTP"
+        },
+        "5500": {
+          "allowed": false,
+          "reason": "Virtual Network Computing (VNC) Remote Frame Buffer Protocol"
+        }
+      }
+    },
+    "udp": {
+      "ports": {
+        "69": {
+          "allowed": false,
+          "reason": "Trivial File Transfer Protocol (TFTP) Server"
+        },
+        "123": {
           "allowed": true,
-          "reason": "Testing snet-sensor-mgmt"
+          "reason": "Network Time Protocol (NTP) Server"
+        },
+        "161": {
+          "allowed": false,
+          "reason": "Simple Network Management Protocol (SNMP)"
+        },
+        "162": {
+          "allowed": false,
+          "reason": "Simple Network Management Protocol (SNMP) Trap"
+        },
+        "47808": {
+          "allowed": false,
+          "reason": "BACnet protocol"
         }
       }
     }

--- a/qualification/device_type_module_config.json
+++ b/qualification/device_type_module_config.json
@@ -5,7 +5,7 @@
   "device_info": {
     "make": "*** Make ***",
     "model": "*** Model ***",
-    "type": "*** Type ***",
+    "type": "*** Type ***"
   },
   "device_manuals_url": "*** Device Manuals URL ***",
   "modules": {

--- a/qualification/system_module_config.json
+++ b/qualification/system_module_config.json
@@ -94,7 +94,7 @@
       "required": "pass",
       "expected": "Required Pass for PoE Devices"
     },
-    "network.brute": {
+    "security.brute": {
       "category": "Security",
       "required": "pass",
       "expected": "Required Pass"

--- a/subset/pentests/readme.md
+++ b/subset/pentests/readme.md
@@ -10,10 +10,18 @@ python brute_client.py <ip_address> <port> <report_filename>
 python brute_server.py <ip_address> <port> <simultaneous_clients>
 ```
 
+Tests included in this module:
+
+* security.brute
+
 ## test_discover
 
 The discover test module attempts to find information from devices automatically.
 It is composed of the BACnet firmware test.
+
+Tests included in this module:
+
+* security.firmware
 
 ### Conditions for security.firmware:  
 
@@ -21,3 +29,17 @@ It is composed of the BACnet firmware test.
 * fail -> version DOES NOT match device_info.firmware_version  
 * info -> version found from device but none defined in device_info.firmware_version  
 * skip -> cannot get firmware version from device, ports may be filtered   
+
+## test_nmap
+
+The nmap module uses the nmap tool to check open ports and validates them in relation
+to the policy that is set in the module_config.json file or files.
+
+Tests included in this module:
+
+* security.nmap.ports
+
+### Conditions for security.nmap.ports
+
+* pass -> all the ports configured in module_config.json agree with the allow/deny policy
+* fail -> one or more of the ports configured in module_config.json do not agree with the allow/deny policy

--- a/subset/pentests/test_brute
+++ b/subset/pentests/test_brute
@@ -4,7 +4,7 @@ source reporting.sh
 PORT=10000
 REPORT=/tmp/report.txt
 
-TEST_NAME="network.brute"
+TEST_NAME="security.brute"
 TEST_DESCRIPTION="Educational test - not to be included in a production environment!"
 TEST_SUMMARY=""
 LOG=/tmp/brute.log

--- a/subset/pentests/test_nmap
+++ b/subset/pentests/test_nmap
@@ -19,22 +19,36 @@ fi
 
 ping -n -c 3 $TARGET_IP
 
-echo Testing target $TARGET_IP port 23
+echo Testing target $TARGET_IP port 23 \(telnet\)
 nc -nzv $TARGET_IP -w 5 23 || true
 nc -nzv $TARGET_IP -w 5 23 || true
 sleep 1
 nc -nzv $TARGET_IP -w 5 23 || true
 sleep 1
 
-nmap -v -n -Pn -T4 --open -oG $LOG $TARGET_IP
+# get list of ports to be scanned from module_config.json
+ports="U:0,"
+for k in $(jq '.servers.udp.ports | keys | .[]' $CONFIG); do
+	echo $k
+        ports=$ports$k","
+done
+ports=$ports"T:0,"
+for k in $(jq '.servers.tcp.ports | keys | .[]' $CONFIG); do
+        echo $k
+        ports=$ports$k","
+done
+portslist=$(echo $ports | sed 's/"//g')
+
+echo Testing target $TARGET_IP to check open ports $portslist
+nmap -v -n -Pn -T5 -sU -sT --open -p$portslist -oG $LOG $TARGET_IP
 cat $LOG
 
 touch $REDACTED_LOG
 touch $REPORT
 rm -f .fail
-grep -oh '[0-9]*/open/[^[:space:]]*' $LOG | while IFS=/ read -ra parts; do
+grep -oh '[0-9]*/open[^[:space:]]*' $LOG | while IFS=/ read -ra parts; do
     state=${parts[1]}
-    if [ "$state" == open ]; then
+    if [ "$state" == open ] || [ "$state" == "open|filtered" ]; then
         if [ -f $CONFIG ]; then
             port=${parts[0]}
             proto=${parts[2]}
@@ -56,10 +70,11 @@ if [ -f .fail ]; then
     echo Open ports:
     cat $REDACTED_LOG
     result=fail
-    SUMMARY="Some disallowed ports are open"
+    SUMMARY="Some disallowed ports are open."
 else
     echo No invalid ports found. | tee -a $REDACTED_LOG
     result=pass
+    SUMMARY="Only allowed ports found open."
 fi
 
 RESULT_AND_SUMMARY="RESULT $result $TEST_NAME $SUMMARY"

--- a/subset/pentests/test_nmap
+++ b/subset/pentests/test_nmap
@@ -1,10 +1,12 @@
 #!/bin/bash -e
+
 source reporting.sh
+CONFIG=/config/device/module_config.json
+
 #source ../../utils/reporting.sh
+#CONFIG=../../qualification/device_type_module_config.json
 
 REPORT=/tmp/report.txt
-CONFIG=/config/device/module_config.json
-#CONFIG=../../qualification/device_type_module_config.json
 LOG=/tmp/nmap.log
 OPENPORTSLIST_LOG=/tmp/nmap.ports.log
 REDACTED_LOG=/tmp/nmap.report.log
@@ -35,16 +37,20 @@ sleep 1
 nc -nzv $TARGET_IP -w 5 23 || true
 sleep 1
 
-# get list of ports to be scanned from module_config.json
-ports="U:0,"
-for k in $(jq '.servers.udp.ports | keys | .[]' $CONFIG); do
-  ports=$ports$k","
-done
-ports=$ports"T:0,"
-for k in $(jq '.servers.tcp.ports | keys | .[]' $CONFIG); do
-  ports=$ports$k","
-done
-portslist=$(echo $ports | sed 's/"//g')
+if [ -f $CONFIG ]; then
+  # get list of ports to be scanned from module_config.json
+  ports="U:"
+  for k in $(jq '.servers.udp.ports | keys | .[]' $CONFIG); do
+    ports=$ports$k","
+  done
+  ports=$ports"T:"
+  for k in $(jq '.servers.tcp.ports | keys | .[]' $CONFIG); do
+    ports=$ports$k","
+  done
+  portslist=$(echo $ports | sed 's/"//g')
+else
+  portslist=1-1024
+fi
 
 echo -e "\nTesting target $TARGET_IP to check open ports $portslist"
 nmap -v -n -Pn -T5 -sU -sT --open -p$portslist -oG $LOG $TARGET_IP

--- a/subset/pentests/test_nmap
+++ b/subset/pentests/test_nmap
@@ -1,9 +1,14 @@
 #!/bin/bash -e
 source reporting.sh
+#source ../../utils/reporting.sh
 
 REPORT=/tmp/report.txt
 CONFIG=/config/device/module_config.json
+#CONFIG=../../qualification/device_type_module_config.json
+cat $CONFIG
 LOG=/tmp/nmap.log
+OPENPORTSLIST=""
+SUMMARYTABLE=""
 
 TEST_NAME="security.ports.nmap"
 TEST_DESCRIPTION="Automatic TCP/UDP port scan using nmap"
@@ -55,6 +60,7 @@ grep -oh '[0-9]*/open[^[:space:]]*' $LOG | while IFS=/ read -ra parts; do
             allowed=$(jq ".servers.$proto.ports.\"$port\".allowed" $CONFIG)
             if [ "$allowed" != true ]; then
                 echo Failing ${parts[*]} | tee -a $REDACTED_LOG
+                OPENPORTSLIST=$OPENPORTSLIST","${parts[*]}
                 touch .fail
             else
                 echo Allowing ${parts[*]} | tee -a $REDACTED_LOG
@@ -70,7 +76,7 @@ if [ -f .fail ]; then
     echo Open ports:
     cat $REDACTED_LOG
     result=fail
-    SUMMARY="Some disallowed ports are open."
+    SUMMARY="Some disallowed ports are open:"$OPENPORTSLIST
 else
     echo No invalid ports found. | tee -a $REDACTED_LOG
     result=pass

--- a/subset/pentests/test_nmap
+++ b/subset/pentests/test_nmap
@@ -57,6 +57,7 @@ nmap -v -n -Pn -T5 -sU -sT --open -p$portslist -oG $LOG $TARGET_IP
 cat $LOG
 
 touch $REDACTED_LOG
+cat $LOG | tee -a $REDACTED_LOG
 touch $REPORT
 touch $OPENPORTSLIST_LOG
 rm -f .fail

--- a/subset/pentests/test_nmap
+++ b/subset/pentests/test_nmap
@@ -5,15 +5,18 @@ source reporting.sh
 REPORT=/tmp/report.txt
 CONFIG=/config/device/module_config.json
 #CONFIG=../../qualification/device_type_module_config.json
-cat $CONFIG
 LOG=/tmp/nmap.log
-OPENPORTSLIST=""
-SUMMARYTABLE=""
+OPENPORTSLIST_LOG=/tmp/nmap.ports.log
+REDACTED_LOG=/tmp/nmap.report.log
 
 TEST_NAME="security.ports.nmap"
 TEST_DESCRIPTION="Automatic TCP/UDP port scan using nmap"
 SUMMARY=""
-REDACTED_LOG=/tmp/nmap.report.log
+
+rm -f $LOG
+rm -f $REDACTED_LOG
+rm -f $OPENPORTSLIST_LOG
+rm -f $REPORT
 
 if [ -f $CONFIG ]; then
     echo Extracting servers config from $CONFIG
@@ -22,9 +25,10 @@ else
     echo No module config $CONFIG
 fi
 
+echo -e "\nPinging target $TARGET_IP"
 ping -n -c 3 $TARGET_IP
 
-echo Testing target $TARGET_IP port 23 \(telnet\)
+echo -e "\nTesting target $TARGET_IP port 23 (telnet)"
 nc -nzv $TARGET_IP -w 5 23 || true
 nc -nzv $TARGET_IP -w 5 23 || true
 sleep 1
@@ -34,23 +38,23 @@ sleep 1
 # get list of ports to be scanned from module_config.json
 ports="U:0,"
 for k in $(jq '.servers.udp.ports | keys | .[]' $CONFIG); do
-	echo $k
-        ports=$ports$k","
+  ports=$ports$k","
 done
 ports=$ports"T:0,"
 for k in $(jq '.servers.tcp.ports | keys | .[]' $CONFIG); do
-        echo $k
-        ports=$ports$k","
+  ports=$ports$k","
 done
 portslist=$(echo $ports | sed 's/"//g')
 
-echo Testing target $TARGET_IP to check open ports $portslist
+echo -e "\nTesting target $TARGET_IP to check open ports $portslist"
 nmap -v -n -Pn -T5 -sU -sT --open -p$portslist -oG $LOG $TARGET_IP
 cat $LOG
 
 touch $REDACTED_LOG
 touch $REPORT
+touch $OPENPORTSLIST_LOG
 rm -f .fail
+openportslist=" - "
 grep -oh '[0-9]*/open[^[:space:]]*' $LOG | while IFS=/ read -ra parts; do
     state=${parts[1]}
     if [ "$state" == open ] || [ "$state" == "open|filtered" ]; then
@@ -59,14 +63,14 @@ grep -oh '[0-9]*/open[^[:space:]]*' $LOG | while IFS=/ read -ra parts; do
             proto=${parts[2]}
             allowed=$(jq ".servers.$proto.ports.\"$port\".allowed" $CONFIG)
             if [ "$allowed" != true ]; then
-                echo Failing ${parts[*]} | tee -a $REDACTED_LOG
-                OPENPORTSLIST=$OPENPORTSLIST","${parts[*]}
                 touch .fail
+                echo Failing ${parts[*]} | sed 's/,$//' | tee -a $REDACTED_LOG
+                echo ${parts[0]}"," | tee -a $OPENPORTSLIST_LOG
             else
-                echo Allowing ${parts[*]} | tee -a $REDACTED_LOG
+                echo Allowing ${parts[*]} | sed 's/,$//' | tee -a $REDACTED_LOG
             fi
         else
-            echo Open port ${parts[*]} | tee -a $REDACTED_LOG
+            echo Open port ${parts[*]} | sed 's/,$//' | tee -a $REDACTED_LOG
             touch .fail
         fi
     fi
@@ -76,7 +80,7 @@ if [ -f .fail ]; then
     echo Open ports:
     cat $REDACTED_LOG
     result=fail
-    SUMMARY="Some disallowed ports are open:"$OPENPORTSLIST
+    SUMMARY="Some disallowed ports are open: `cat $OPENPORTSLIST_LOG | sed 's/,$//'`"
 else
     echo No invalid ports found. | tee -a $REDACTED_LOG
     result=pass

--- a/testing/test_aux.out
+++ b/testing/test_aux.out
@@ -30,18 +30,14 @@ RESULT skip security.passwords.telnet Could not lookup password info for mac-key
 RESULT skip security.passwords.ssh Could not lookup password info for mac-key 9a:02:57:1e:8f:01
 RESULT fail security.passwords.http Default passwords has not been changed
 RESULT fail security.passwords.https Default passwords has not been changed
-RESULT pass security.passwords.telnet  Default passwords have been changed
+RESULT fail security.passwords.telnet Default passwords has not been changed
 RESULT fail security.passwords.ssh Default passwords have not been changed
-RESULT pass security.passwords.http  Default passwords have been changed
-RESULT pass security.passwords.https  Default passwords have been changed
-RESULT pass security.passwords.telnet  Default passwords have been changed
-RESULT pass security.passwords.ssh Default passwords have been changed
 RESULT skip security.firmware Could not retrieve a firmware version with nmap. Check bacnet port.
 RESULT pass security.firmware version found: ?\xFF\xFF\x19,>u\x08\x00no
 dhcp requests 2 1
 01: ['01:brute:1', '01:macoui:1']
 02: ['02:hold:TimeoutError', '02:macoui:TimeoutError', '02:nmap:1', '02:tls:1']
-03: ['03:hold:DaqException']
+03: ['03:hold:DaqException', '03:password:TimeoutError']
 ctrl-br.flows
 ctrl-br.ofctl
 ext-ovs.flows
@@ -145,11 +141,8 @@ port-02 module_config modules
     `'''       `\__   /\
                 ')
 Redacted docs diff
-125c125
-< # Nmap 7.60 scan initiated XXX as: nmap -v -n -Pn -T5 -sU -sT --open -pU:123,161,162,47808,69,T:110,143,161,162,20,21,22,23,25,443,5500,5800,80, -oG /tmp/nmap.log 10.20.33.164
----
-> # Nmap 7.60 scan initiated XXX as: nmap -v -n -Pn -T5 -sU -sT --open -pU:123,161,162,47808,69,T:110,143,161,162,20,21,22,23,25,443,5500,5800,80, -oG /tmp/nmap.log 10.20.59.164
- M qualification/system_module_config.json
+ M docs/device_report.md
+ M testing/test_aux.out
  M testing/test_aux.sh
  M testing/test_base.out
  M testing/test_base.sh

--- a/testing/test_aux.out
+++ b/testing/test_aux.out
@@ -30,7 +30,7 @@ RESULT skip security.passwords.telnet Could not lookup password info for mac-key
 RESULT skip security.passwords.ssh Could not lookup password info for mac-key 9a:02:57:1e:8f:01
 RESULT fail security.passwords.http Default passwords has not been changed
 RESULT fail security.passwords.https Default passwords has not been changed
-RESULT fail security.passwords.telnet Default passwords has not been changed
+RESULT pass security.passwords.telnet  Default passwords have been changed
 RESULT fail security.passwords.ssh Default passwords have not been changed
 RESULT pass security.passwords.http  Default passwords have been changed
 RESULT pass security.passwords.https  Default passwords have been changed
@@ -145,42 +145,14 @@ port-02 module_config modules
     `'''       `\__   /\
                 ')
 Redacted docs diff
-57c57
-< |Required|1|1|0|0|
+125c125
+< # Nmap 7.60 scan initiated XXX as: nmap -v -n -Pn -T5 -sU -sT --open -pU:123,161,162,47808,69,T:110,143,161,162,20,21,22,23,25,443,5500,5800,80, -oG /tmp/nmap.log 10.20.33.164
 ---
-> |Required|1|0|0|0|
-59c59
-< |Other|0|1|17|2|
----
-> |Other|0|2|17|2|
-70d69
-< |fail|network.brute|Security|Required|Change the default password on the DUT|
-75a75
-> |fail|security.brute|Other|Other|Change the default password on the DUT|
-81c81
-< |pass|security.ports.nmap|Security|Recommended||
----
-> |pass|security.ports.nmap|Security|Recommended|Only allowed ports found open.|
-126c126,128
-< Allowing 10000 open tcp snet-sensor-mgmt
----
-> # Nmap 7.60 scan initiated Fri Feb 21 18:10:24 2020 as: nmap -v -n -Pn -T5 -sU -sT --open -pU:123,161,162,47808,69,T:110,143,161,162,20,21,22,23,25,443,5500,5800,80, -oG /tmp/nmap.log 10.20.33.164
-> # Ports scanned: TCP(13;20-23,25,80,110,143,161-162,443,5500,5800) UDP(5;69,123,161-162,47808) SCTP(0;) PROTOCOLS(0;)
-> # Nmap done at Fri Feb 21 18:10:24 2020 -- 1 IP address (1 host up) scanned in 0.58 seconds
-129c131
-< RESULT pass security.ports.nmap 
----
-> RESULT pass security.ports.nmap Only allowed ports found open.
-137c139
-< network.brute
----
-> security.brute
-145c147
-< RESULT fail network.brute Change the default password on the DUT
----
-> RESULT fail security.brute Change the default password on the DUT
- M subset/pentests/test_nmap
+> # Nmap 7.60 scan initiated XXX as: nmap -v -n -Pn -T5 -sU -sT --open -pU:123,161,162,47808,69,T:110,143,161,162,20,21,22,23,25,443,5500,5800,80, -oG /tmp/nmap.log 10.20.59.164
+ M qualification/system_module_config.json
  M testing/test_aux.sh
+ M testing/test_base.out
+ M testing/test_base.sh
 01: ['01:ping:Exception']
 02: ['02:ping:ValueError']
 03: ['03:nmap:1', '03:ping:Exception']

--- a/testing/test_aux.out
+++ b/testing/test_aux.out
@@ -10,11 +10,11 @@ ERROR:host:Monitoring timeout for macoui after 1s
 RESULT skip protocol.bacnet.version Bacnet device not found.
 RESULT skip protocol.bacnet.pic Bacnet device not found.
 RESULT info protocol.bacnet.version Protocol version: 1
-RESULT skip protocol.bacnet.pic Bacnet device not found. pics.csv not found in device_types/../aux/ directory 
+RESULT skip protocol.bacnet.pic Bacnet device not found. pics.csv not found in device_types/../aux/ directory
 RESULT info protocol.bacnet.version Protocol version: 1
 RESULT pass protocol.bacnet.pic
 RESULT fail security.brute Change the default password on the DUT
-RESULT pass security.brute 
+RESULT pass security.brute
 RESULT skip security.brute Port 10000 is not open
 RESULT fail connection.mac_oui Manufacturer prefix not found!
 RESULT pass connection.mac_oui
@@ -32,12 +32,16 @@ RESULT fail security.passwords.http Default passwords has not been changed
 RESULT fail security.passwords.https Default passwords has not been changed
 RESULT fail security.passwords.telnet Default passwords has not been changed
 RESULT fail security.passwords.ssh Default passwords have not been changed
+RESULT pass security.passwords.http  Default passwords have been changed
+RESULT pass security.passwords.https  Default passwords have been changed
+RESULT pass security.passwords.telnet  Default passwords have been changed
+RESULT pass security.passwords.ssh Default passwords have been changed
 RESULT skip security.firmware Could not retrieve a firmware version with nmap. Check bacnet port.
 RESULT pass security.firmware version found: ?\xFF\xFF\x19,>u\x08\x00no
 dhcp requests 2 1
 01: ['01:brute:1', '01:macoui:1']
 02: ['02:hold:TimeoutError', '02:macoui:TimeoutError', '02:nmap:1', '02:tls:1']
-03: ['03:hold:DaqException', '03:password:TimeoutError']
+03: ['03:hold:DaqException']
 ctrl-br.flows
 ctrl-br.ofctl
 ext-ovs.flows
@@ -141,12 +145,8 @@ port-02 module_config modules
     `'''       `\__   /\
                 ')
 Redacted docs diff
- M docs/device_report.md
- M testing/test_aux.out
- M testing/test_aux.sh
- M testing/test_base.out
- M testing/test_base.sh
+No report diff
 01: ['01:ping:Exception']
-02: ['02:ping:ValueError']
+02: ['02:nmap:1', '02:ping:ValueError']
 03: ['03:nmap:1', '03:ping:Exception']
 Done with tests

--- a/testing/test_aux.out
+++ b/testing/test_aux.out
@@ -13,9 +13,9 @@ RESULT info protocol.bacnet.version Protocol version: 1
 RESULT skip protocol.bacnet.pic Bacnet device not found. pics.csv not found in device_types/../aux/ directory 
 RESULT info protocol.bacnet.version Protocol version: 1
 RESULT pass protocol.bacnet.pic
-RESULT fail network.brute Change the default password on the DUT
-RESULT pass network.brute 
-RESULT skip network.brute Port 10000 is not open
+RESULT fail security.brute Change the default password on the DUT
+RESULT pass security.brute 
+RESULT skip security.brute Port 10000 is not open
 RESULT fail connection.mac_oui Manufacturer prefix not found!
 RESULT pass connection.mac_oui
 RESULT skip security.tls.v3
@@ -41,7 +41,7 @@ RESULT pass security.firmware version found: ?\xFF\xFF\x19,>u\x08\x00no
 dhcp requests 2 1
 01: ['01:brute:1', '01:macoui:1']
 02: ['02:hold:TimeoutError', '02:macoui:TimeoutError', '02:nmap:1', '02:tls:1']
-03: ['03:hold:DaqException', '03:nmap:1']
+03: ['03:hold:DaqException']
 ctrl-br.flows
 ctrl-br.ofctl
 ext-ovs.flows
@@ -107,7 +107,7 @@ port-02 module_config modules
     "timeout_sec": 120
   },
   "hold": {
-    "enabled": true 
+    "enabled": true
   },
   "macoui": {
     "enabled": true,
@@ -145,8 +145,43 @@ port-02 module_config modules
     `'''       `\__   /\
                 ')
 Redacted docs diff
-No report diff
+57c57
+< |Required|1|1|0|0|
+---
+> |Required|1|0|0|0|
+59c59
+< |Other|0|1|17|2|
+---
+> |Other|0|2|17|2|
+70d69
+< |fail|network.brute|Security|Required|Change the default password on the DUT|
+75a75
+> |fail|security.brute|Other|Other|Change the default password on the DUT|
+81c81
+< |pass|security.ports.nmap|Security|Recommended||
+---
+> |pass|security.ports.nmap|Security|Recommended|Only allowed ports found open.|
+126c126,128
+< Allowing 10000 open tcp snet-sensor-mgmt
+---
+> # Nmap 7.60 scan initiated Fri Feb 21 18:10:24 2020 as: nmap -v -n -Pn -T5 -sU -sT --open -pU:123,161,162,47808,69,T:110,143,161,162,20,21,22,23,25,443,5500,5800,80, -oG /tmp/nmap.log 10.20.33.164
+> # Ports scanned: TCP(13;20-23,25,80,110,143,161-162,443,5500,5800) UDP(5;69,123,161-162,47808) SCTP(0;) PROTOCOLS(0;)
+> # Nmap done at Fri Feb 21 18:10:24 2020 -- 1 IP address (1 host up) scanned in 0.58 seconds
+129c131
+< RESULT pass security.ports.nmap 
+---
+> RESULT pass security.ports.nmap Only allowed ports found open.
+137c139
+< network.brute
+---
+> security.brute
+145c147
+< RESULT fail network.brute Change the default password on the DUT
+---
+> RESULT fail security.brute Change the default password on the DUT
+ M subset/pentests/test_nmap
+ M testing/test_aux.sh
 01: ['01:ping:Exception']
 02: ['02:ping:ValueError']
-03: ['03:ping:Exception']
+03: ['03:nmap:1', '03:ping:Exception']
 Done with tests

--- a/testing/test_aux.sh
+++ b/testing/test_aux.sh
@@ -145,12 +145,14 @@ echo done with docker logs
 # Remove things that will always (probably) change - like DAQ version/timestamps/IPs
 # from comparison
 function redact {
-    sed -E -e '/^%%.*/d' \
+    sed -E -e "s/ \{1,\}$//" \
         -e 's/\s*%%.*//' \
         -e 's/[0-9]{4}-.*T.*Z/XXX/' \
         -e 's/[a-zA-Z]{3} [a-zA-Z]{3} [0-9]{1,2} [0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2} [0-9]{4}/XXX/' \
-        -e 's/[0-9]{4}-(0|1)[0-9]-(0|1|2|3)[0-9] [0-9]{2}:[0-9]{2}:[0-9]{2}\+00:00/XXX/g' \
-        -e 's/DAQ version.*//'
+        -e 's/[0-9]{4}-(0|1)[0-9]-(0|1|2|3)[0-9] [0-9]{2}:[0-9]{2}:[0-9]{2}\+00:00/XXX/' \
+        -e 's/DAQ version.*//' \
+        -e 's/[0-9].[0-9]{2} seconds/XXX/' \
+        -e 's/\b(?:\d{1,3}\.){3}\d{1,3}\b/XXX/'
 }
 # Make sure that what you've done hasn't messed up DAQ by diffing the output from your test run
 cat docs/device_report.md | redact > out/redacted_docs.md

--- a/testing/test_aux.sh
+++ b/testing/test_aux.sh
@@ -19,7 +19,7 @@ bin/check_style
 echo check_style exit code $? | tee -a $TEST_RESULTS
 
 # Remove report file for faux-1 device
-rm -f inst/reports/report_9a02571e8f01_*.md
+rm -f out/report_9a02571e8f01_*.md
 
 # Function to create pubber config files (for use in cloud tests)
 
@@ -145,8 +145,10 @@ echo done with docker logs
 # Remove things that will always (probably) change - like DAQ version/timestamps/IPs
 # from comparison
 function redact {
-    sed -E -e 's/\s*%%.*//' \
+    sed -E -e '/^%%.*/d' \
+        -e 's/\s*%%.*//' \
         -e 's/[0-9]{4}-.*T.*Z/XXX/' \
+        -e 's/[a-zA-Z]{3} [a-zA-Z]{3} [0-9]{1,2} [0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2} [0-9]{4}/XXX/' \
         -e 's/[0-9]{4}-(0|1)[0-9]-(0|1|2|3)[0-9] [0-9]{2}:[0-9]{2}:[0-9]{2}\+00:00/XXX/g' \
         -e 's/DAQ version.*//'
 }

--- a/testing/test_aux.sh
+++ b/testing/test_aux.sh
@@ -18,6 +18,9 @@ echo Lint checks | tee -a $TEST_RESULTS
 bin/check_style
 echo check_style exit code $? | tee -a $TEST_RESULTS
 
+# Remove report file for faux-1 device
+rm -f inst/reports/report_9a02571e8f01_*.md
+
 # Function to create pubber config files (for use in cloud tests)
 
 function make_pubber {
@@ -149,6 +152,7 @@ function redact {
 }
 # Make sure that what you've done hasn't messed up DAQ by diffing the output from your test run
 cat docs/device_report.md | redact > out/redacted_docs.md
+cp inst/reports/report_9a02571e8f01_*.md out/
 cat inst/reports/report_9a02571e8f01_*.md | redact > out/redacted_file.md
 
 echo Redacted docs diff | tee -a $TEST_RESULTS

--- a/testing/test_base.out
+++ b/testing/test_base.out
@@ -38,7 +38,6 @@ Overall device result PASS
 ```
 --------------------
 Baseline ping test report
-
 LOCAL_IP not configured, assuming no network switch
 
 Done with basic connectivity tests

--- a/testing/test_base.out
+++ b/testing/test_base.out
@@ -38,6 +38,7 @@ Overall device result PASS
 ```
 --------------------
 Baseline ping test report
+
 LOCAL_IP not configured, assuming no network switch
 
 Done with basic connectivity tests

--- a/testing/test_base.out
+++ b/testing/test_base.out
@@ -1,6 +1,6 @@
 Running testing/test_base.sh
 Base Tests
-01: []
+01: ['01:nmap:1']
 # Device 9a02571e8f00, XXX to XXX
 
 Sample device description.
@@ -24,14 +24,13 @@ Overall device result PASS
 
 |Expectation|skip|pass|
 |---|---|---|
-|Other|2|2|
+|Other|2|1|
 
 |Result|Test|Category|Expectation|Notes|
 |---|---|---|---|---|
 |skip|base.switch.ping|Other|Other|No local IP has been set, check ext_loip in system.conf|
 |pass|base.target.ping|Other|Other|target reached|
-|skip|network.brute|Other|Other|Port 10000 is not open|
-|pass|security.ports.nmap|Other|Other||
+|skip|security.brute|Other|Other|Port 10000 is not open|
 
 
 ## Module ping
@@ -64,31 +63,17 @@ RESULT pass base.target.ping target reached
 
 ```
 
-## Module nmap
-
-```
---------------------
-security.ports.nmap
---------------------
-Automatic TCP/UDP port scan using nmap
---------------------
-No invalid ports found.
---------------------
-RESULT pass security.ports.nmap 
-
-```
-
 ## Module brute
 
 ```
 --------------------
-network.brute
+security.brute
 --------------------
 Educational test - not to be included in a production environment!
 --------------------
 Target port 10000 not open.
 --------------------
-RESULT skip network.brute Port 10000 is not open
+RESULT skip security.brute Port 10000 is not open
 
 ```
 
@@ -96,15 +81,9 @@ RESULT skip network.brute Port 10000 is not open
 
 Open port tests
 01: ['01:nmap:1']
-|fail|security.ports.nmap|Other|Other|Some disallowed ports are open|
-security.ports.nmap
-RESULT fail security.ports.nmap Some disallowed ports are open
-01: []
-|pass|security.ports.nmap|Other|Other||
-security.ports.nmap
-RESULT pass security.ports.nmap
+01: ['01:nmap:1']
 External switch tests
-02: []
+02: ['02:nmap:1']
     dp_id: 1
     dp_id: 4886718345
 Switch test with port 2

--- a/testing/test_base.sh
+++ b/testing/test_base.sh
@@ -5,12 +5,13 @@ source testing/test_preamble.sh
 echo Base Tests >> $TEST_RESULTS
 
 function redact {
-    sed -E -e '/^%%.*/d' \
+    sed -E -e "s/ \{1,\}$//" \
         -e 's/\s*%%.*//' \
         -e 's/[0-9]{4}-.*T.*Z/XXX/' \
         -e 's/[a-zA-Z]{3} [a-zA-Z]{3} [0-9]{1,2} [0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2} [0-9]{4}/XXX/' \
         -e 's/[0-9]{4}-(0|1)[0-9]-(0|1|2|3)[0-9] [0-9]{2}:[0-9]{2}:[0-9]{2}\+00:00/XXX/g' \
-        -e 's/DAQ version.*//'
+        -e 's/DAQ version.*//' \
+        -e 's/[0-9].[0-9]{2} seconds/XXX/'
 }
 
 cp misc/system_base.conf local/system.conf

--- a/testing/test_base.sh
+++ b/testing/test_base.sh
@@ -5,8 +5,10 @@ source testing/test_preamble.sh
 echo Base Tests >> $TEST_RESULTS
 
 function redact {
-    sed -E -e 's/\s*%%.*//' \
+    sed -E -e '/^%%.*/d' \
+        -e 's/\s*%%.*//' \
         -e 's/[0-9]{4}-.*T.*Z/XXX/' \
+        -e 's/[a-zA-Z]{3} [a-zA-Z]{3} [0-9]{1,2} [0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2} [0-9]{4}/XXX/' \
         -e 's/[0-9]{4}-(0|1)[0-9]-(0|1|2|3)[0-9] [0-9]{2}:[0-9]{2}:[0-9]{2}\+00:00/XXX/g' \
         -e 's/DAQ version.*//'
 }


### PR DESCRIPTION
Hi @grafnu and @spectre-storm, here is a PR for getting the `nmap` port scan tests to a usable/useful state. 

I've implemented the following:

1. Only the ports selected in `module_config.json` are scanned.
2. Change to the `nmap` command to both scan for UDP and TCP open ports from the selected list: `nmap -v -n -Pn -T5 -sU -sT --open -p$portslist -oG $LOG $TARGET_IP`.
3. Included slightly more verbose output from `nmap` in the report details.
4. Included a description of the `test_nmap` module in the appropriate `readme.md` file.
5. Extensive tests to check that this module works both with faux devices and with physical devices.

Originally, I wanted to do a full port scan using a command like `nmap -v -n -Pn -T5 -sU -sT --open -p0-65535 -oG $LOG $TARGET_IP` and this worked well when I tested it outside of DAQ (scan time less than 2 minutes). However when I checked the test inside DAQ it took more than 1 hour, so I choose to test only the ports specified in `module_config.json`. 
I'd like to investigate this as I think doing a full port scan would be better (at the moment the test only checks specified ports, so by design it misses potential open ports that have not been specified - this is according to the test plan, but a full scan would be more informative).

@grafnu can you provide some comments about why the full scan takes so much longer inside DAQ before I start researching? 

Thanks!
F